### PR TITLE
docs: update UI Options page with new instructions

### DIFF
--- a/src/uioptions.html
+++ b/src/uioptions.html
@@ -14,18 +14,12 @@ permalink: ui-options.html
       </p>
       <h3>Get UI Options</h3>
       <p>
-      For Wordpress: <a href="https://github.com/fluid-project/uio-wordpress-plugin">UI Options Wordpress Plugin</a>.
+      There are a number of different ways to get UI Options for your project. Visit <a href="https://docs.fluidproject.org/infusion/development/tutorial-userinterfaceoptions/gettinguioptions">Infusion Docs | Getting User Interface Options</a> to choose the best method for your situation.
       </p>
 
-      <p>
-      From source code: <a href="https://www.npmjs.com/package/infusion">using npm</a>, or <a href="https://github.com/fluid-project/infusion/releases">GitHub</a>.
-      </p>
       <h3>Guides and Documentation</h3>
       <p>
-      If installing UI Options using npm or from a release on GitHub (not applicable if using the Wordpress plugin), "<a href="https://docs.fluidproject.org/infusion/development/tutorial-userInterfaceOptions/UserInterfaceOptions.html">Setting Up User Interface Options</a>" will help installing and structuring your code.
-      </p>
-      <p>
-      Once UI Options is installed, <a href="https://docs.fluidproject.org/infusion/development/tutorial-userInterfaceOptions/WorkingWithUserInterfaceOptions.html">"Working with UI Options"</a> can help guide you through setting up your site's styles and markup to take advantage of UI Options.
+      <a href="https://docs.fluidproject.org/infusion/development/tutorial-userInterfaceOptions/UserInterfaceOptions.html">Infusion Docs | Setting Up User Interface Options</a> is a guide that will help you get started with using User Interface Options in your project. Once you have UI Options installed in your project, <a href="https://docs.fluidproject.org/infusion/development/tutorial-userInterfaceOptions/WorkingWithUserInterfaceOptions.html">Infusion Docs | Working with UI Options</a> can help guide you through conifguring your site's styles and markup to take advantage of UI Options.
       </p>
     </article>
 


### PR DESCRIPTION
Update the UI Options page on the Floe site to match the new documentation available on Infusion Docs.